### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig: https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Adds a `.editorconfig` file to the repository root with sensible defaults per #9
- UTF-8 charset, LF line endings, trailing whitespace trimming, final newline insertion
- 4-space indentation for most files, 2-space for YAML and JSON

## Test plan
- [ ] Verify `.editorconfig` is recognized by editors/IDEs (VS Code, IntelliJ, etc.)
- [ ] Confirm indentation defaults apply correctly to new files

Closes #9