### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @zengenuity/dev-team


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file that assigns `@zengenuity/dev-team` as the default code owner for all files.

Closes #12