### PR TITLE
Add .editorconfig with sensible defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Adds a root `.editorconfig` defining UTF-8, LF line endings, 4-space indentation, trailing-whitespace trimming, and final-newline insertion.
- Overrides indentation to 2 spaces for YAML and JSON files.

Closes #17

## Test plan
- [ ] Verify `.editorconfig` is present at the repo root.
- [ ] Open a file in an EditorConfig-aware editor and confirm the settings are applied.