### PR TITLE
Add .editorconfig with sensible defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Adds a `.editorconfig` at the repository root with UTF-8 charset, LF line endings, final newline, and trailing whitespace trimming
- Sets 4-space indentation as the default
- Overrides to 2-space indentation for YAML (`*.yml`, `*.yaml`) and JSON (`*.json`)

Closes #19

## Test plan
- [ ] Open a file in an EditorConfig-aware editor and confirm indentation/charset/EOL settings are applied
- [ ] Confirm YAML/JSON files use 2-space indent while other files use 4-space