### PR TITLE
Add .editorconfig with sensible defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Adds a `.editorconfig` at the repo root so editors apply consistent formatting
- Defaults: UTF-8, LF line endings, 4-space indent, trim trailing whitespace, insert final newline
- Override for `*.{yml,yaml,json}`: 2-space indent

Closes #21

## Test plan
- [ ] Open the repo in an EditorConfig-aware editor and confirm the settings apply
- [ ] Open a YAML or JSON file and confirm it uses 2-space indent