### PR TITLE
Add .editorconfig with sensible defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+# EditorConfig: https://editorconfig.org
 root = true
 
 [*]


### PR DESCRIPTION
## Summary
- Adds a root `.editorconfig` defining UTF-8 charset, LF line endings, 4-space indentation, trim trailing whitespace, and insert final newline.
- Overrides indent to 2 spaces for YAML and JSON files.

Closes #23

## Test plan
- [ ] Confirm `.editorconfig` is present at repo root
- [ ] Open a file in an EditorConfig-aware editor and verify the settings apply (4-space indent for general files, 2-space indent for `*.yml`/`*.yaml`/`*.json`)