### PR TITLE
Add .editorconfig with sensible defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+# EditorConfig helps maintain consistent coding styles across editors.
+# See https://editorconfig.org for details.
 root = true
 
 [*]


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` at the repository root so editors apply consistent formatting across contributors.
- Defaults: UTF-8, LF line endings, 4-space indent, trim trailing whitespace, insert final newline.
- Override: 2-space indent for YAML and JSON files.

Closes #25

## Test plan
- [ ] Open a file in an EditorConfig-aware editor and confirm the settings take effect.
- [ ] Open a `.yml`/`.yaml`/`.json` file and confirm indent drops to 2 spaces.