### PR TITLE
Add /health liveness endpoint (Refs #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-Testing
-Test 2
+# test-repo
+
+## Running the server
+
+This project includes a minimal, zero-dependency HTTP server (built on Node's
+`node:http` module) that exposes a health-check endpoint.
+
+Requirements: Node.js >= 18. No third-party dependencies.
+
+```sh
+npm start              # listens on http://0.0.0.0:3000
+PORT=8080 npm start    # override the port (also honors HOST)
+```
+
+## Health check
+
+`GET /health` returns `200` with a small JSON body while the process is able to
+serve HTTP:
+
+```sh
+$ curl -i http://localhost:3000/health
+HTTP/1.1 200 OK
+Content-Type: application/json
+Cache-Control: no-store
+
+{"status":"ok"}
+```
+
+This is a **liveness** check only: the handler performs no database, network, or
+disk I/O, so a slow dependency can't make a healthy process look dead. It is
+unauthenticated and needs no query params or headers. `HEAD /health` is also
+supported for monitors that probe with `HEAD`.
+
+## Tests
+
+```sh
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-repo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Minimal HTTP server exposing a /health liveness endpoint for uptime monitoring.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,53 @@
+const http = require('node:http')
+
+const PORT = process.env.PORT || 3000
+const HOST = process.env.HOST || '0.0.0.0'
+
+// Liveness health check for uptime monitoring (see issue #27).
+//
+// This handler is intentionally cheap and self-contained: it performs no
+// database, network, or disk I/O, so a slow dependency can never make a healthy
+// process look dead. It is unauthenticated and requires no params or headers.
+function handleRequest(req, res) {
+  const { pathname } = new URL(req.url, `http://${req.headers.host || 'localhost'}`)
+
+  if (pathname === '/health') {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.writeHead(405, {
+        Allow: 'GET, HEAD',
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      })
+      res.end(JSON.stringify({ error: 'method_not_allowed' }))
+      return
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    })
+    // A HEAD response carries headers only, never a body.
+    res.end(req.method === 'HEAD' ? undefined : JSON.stringify({ status: 'ok' }))
+    return
+  }
+
+  res.writeHead(404, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+  })
+  res.end(req.method === 'HEAD' ? undefined : JSON.stringify({ error: 'not_found' }))
+}
+
+function createServer() {
+  return http.createServer(handleRequest)
+}
+
+// Only bind a port when run directly (`node src/server.js`), so tests can import
+// createServer and listen on an ephemeral port instead.
+if (require.main === module) {
+  createServer().listen(PORT, HOST, () => {
+    console.log(`Server listening on http://${HOST}:${PORT}`)
+  })
+}
+
+module.exports = { createServer, handleRequest }

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+// Minimal zero-dependency HTTP server whose sole route is the /health
+// liveness check used by uptime monitoring. Run with `npm start`.
 const http = require('node:http')
 
 const PORT = process.env.PORT || 3000

--- a/test/health.test.js
+++ b/test/health.test.js
@@ -1,0 +1,49 @@
+const { test, before, after } = require('node:test')
+const assert = require('node:assert/strict')
+const { createServer } = require('../src/server')
+
+let server
+let baseUrl
+
+before(async () => {
+  server = createServer()
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address()
+  baseUrl = `http://127.0.0.1:${port}`
+})
+
+after(async () => {
+  await new Promise((resolve) => server.close(resolve))
+})
+
+test('GET /health returns 200 with {"status":"ok"}', async () => {
+  const res = await fetch(`${baseUrl}/health`)
+  assert.equal(res.status, 200)
+  assert.equal(res.headers.get('content-type'), 'application/json')
+  assert.equal(res.headers.get('cache-control'), 'no-store')
+  assert.deepEqual(await res.json(), { status: 'ok' })
+})
+
+test('GET /health ignores query params', async () => {
+  const res = await fetch(`${baseUrl}/health?probe=1`)
+  assert.equal(res.status, 200)
+  assert.deepEqual(await res.json(), { status: 'ok' })
+})
+
+test('HEAD /health returns 200 with no body', async () => {
+  const res = await fetch(`${baseUrl}/health`, { method: 'HEAD' })
+  assert.equal(res.status, 200)
+  assert.equal(res.headers.get('cache-control'), 'no-store')
+  assert.equal(await res.text(), '')
+})
+
+test('non-GET/HEAD method on /health returns 405', async () => {
+  const res = await fetch(`${baseUrl}/health`, { method: 'POST' })
+  assert.equal(res.status, 405)
+  assert.equal(res.headers.get('allow'), 'GET, HEAD')
+})
+
+test('unknown route returns 404', async () => {
+  const res = await fetch(`${baseUrl}/nope`)
+  assert.equal(res.status, 404)
+})


### PR DESCRIPTION
## Summary

Implements the `GET /health` liveness endpoint from the PRD on issue #27.

Since the repo had **no application yet** (`master` was just `README.md`, no dependency manifest), this PR also bootstraps the smallest possible server to host the route — exactly the "this issue stands up a minimal server" default the PRD chose for **Q1**.

## What's in here

- **`package.json`** — minimal manifest, no dependencies. `npm start` runs the server, `npm test` runs the suite. `engines.node >= 18`.
- **`src/server.js`** — a tiny `node:http` server. `GET /health` → `200` `{"status":"ok"}` with `Content-Type: application/json` and `Cache-Control: no-store`. `HEAD /health` is supported (headers only). Non-GET/HEAD on `/health` → `405` with `Allow: GET, HEAD`; anything else → `404`. The handler does **no** DB/network/disk I/O (liveness only). Port/host are configurable via `PORT`/`HOST` (default `0.0.0.0:3000`).
- **`test/health.test.js`** — `node:test` suite (no external deps): asserts status, JSON body, `Content-Type`, `Cache-Control`, query-param tolerance, `HEAD`, `405`, and `404`.
- **`README.md`** — documents the run command and the endpoint.

## Contract (matches PRD §5.1)

| Property | Value |
|---|---|
| Method + path | `GET /health` (+ `HEAD`) |
| Success | `200`, `application/json`, `{"status":"ok"}` |
| Auth | none |
| Side effects | none |
| Caching | `Cache-Control: no-store` |

## Acceptance criteria

- [x] `GET /health` returns `200`
- [x] `Content-Type: application/json`, body has a status field (`{"status":"ok"}`)
- [x] No auth, no required params/headers
- [x] No external I/O in the handler
- [x] `Cache-Control: no-store`
- [x] Automated test asserts status code and JSON body
- [x] Server starts via a documented command; endpoint reachable on documented port; README notes both
- [x] `HEAD /health` also returns `200` (Q5)

## Decision I made (please confirm / override)

**Q2 — framework: I used the zero-dependency `node:http` module instead of Express** (the PRD's stated default was Express). Rationale: the PRD explicitly offers `node:http` as the "avoid adding any dependency" alternative and repeatedly asks to keep the skeleton as thin as possible. For an unattended run this is also the more robust choice — it needs no npm-registry access, adds no lockfile or supply-chain surface, and the test suite runs with zero external deps while still satisfying every acceptance criterion. If the team prefers Express for consistency with a future app, swapping the ~50-line handler onto an Express route is trivial and the contract is unchanged.

Other PRD open questions were implemented at their stated defaults: liveness-only (Q3), status field only (Q4), `/health` exactly (Q6).

## Test output

```
# tests 5
# pass 5
# fail 0
```

Refs #27
